### PR TITLE
Increase OS disk size for Ubuntu VMs

### DIFF
--- a/modules/azdo_ubuntuagent/main.tf
+++ b/modules/azdo_ubuntuagent/main.tf
@@ -32,6 +32,7 @@ resource "azurerm_virtual_machine" "VM" {
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Standard_LRS"
+    disk_size_gb = "120"
   }
   os_profile {
     computer_name  = "${var.VM}"

--- a/modules/azdo_ubuntuagent/main.tf
+++ b/modules/azdo_ubuntuagent/main.tf
@@ -32,7 +32,7 @@ resource "azurerm_virtual_machine" "VM" {
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Standard_LRS"
-    disk_size_gb = "120"
+    disk_size_gb      = "128"
   }
   os_profile {
     computer_name  = "${var.VM}"


### PR DESCRIPTION
Increases the size of the Ubuntu OS disk image to 120GB, this originally defaulted to 30GB and teams ran into problems with the agents out of space.

Not increasing the Windows images as they default to 128GB

Fixes #17