### PR TITLE
Trial using compute optimized VMs

### DIFF
--- a/modules/azdo_ubuntuagent/main.tf
+++ b/modules/azdo_ubuntuagent/main.tf
@@ -17,7 +17,7 @@ resource "azurerm_virtual_machine" "VM" {
   location              = "${var.AZURERM_RESOURCE_GROUP_MAIN_LOCATION}"
   resource_group_name   = "${var.AZURERM_RESOURCE_GROUP_MAIN_NAME}"
   network_interface_ids = ["${azurerm_network_interface.VM.id}"]
-  vm_size               = "Standard_D2s_v3"
+  vm_size               = "Standard_F8s_v2"
   delete_os_disk_on_termination = true
   delete_data_disks_on_termination = true
 
@@ -31,7 +31,7 @@ resource "azurerm_virtual_machine" "VM" {
     name              = "${var.PREFIX}-${var.VM}-osdisk"
     caching           = "ReadWrite"
     create_option     = "FromImage"
-    managed_disk_type = "Standard_LRS"
+    managed_disk_type = "Premium_LRS"
     disk_size_gb      = "128"
   }
   os_profile {


### PR DESCRIPTION
Fixes #19 

This PR switches the Ubuntu VMs from Standard_D2s_v3 (2 core, 8GB) to Standard_F8s_v2(8 core, 16GB) to try and decrease build times and timeouts. 

This PR will __substantially__ increase the cost of running these agents. D2s_V3 is £113.17 whereas F8s_v2 is 458.11 per VM. Might try smaller VMs depending on the impact this resize has.

This PR also switches to using premium SSD for the OS disk, rather than normal HDD