### PR TITLE
Add extra server

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -75,8 +75,9 @@ module "pool_agent2-ubuntu" {
   vm_size                                = "${var.VM_SIZE}"
   run_date                               = "${var.RUN_DATE}"
 }
-module "pool_agent3-ws2019-vs2019" {
-  source                                 = "./modules/azdo_ws2019agent"
+
+module "pool_agent3-ubuntu" {
+  source                                 = "./modules/azdo_ubuntuagent"
   VSTS_POOL_PREFIX                       = "${var.VSTS_POOL_PREFIX}"
   VSTS_ACCOUNT                           = "${var.VSTS_ACCOUNT}"
   VSTS_TOKEN                             = "${var.VSTS_TOKEN}"
@@ -90,7 +91,7 @@ module "pool_agent3-ws2019-vs2019" {
   AZURERM_VIRTUAL_NETWORK_MAIN_NAME      = "${data.azurerm_virtual_network.data.name}"
   AZURERM_SUBNET_ID                      = "${data.azurerm_subnet.data.id}"
   AZURERM_NETWORK_SECURITY_GROUP_MAIN_ID = "${data.azurerm_network_security_group.data.id}"
-  VM                                     = "${element(var.SERVERNAMES, 2)}"  
+  VM                                     = "${element(var.SERVERNAMES, 2)}"
   BRANCH                                 = "${var.BRANCH}"
   TAGS                                   = "${var.TAGS}"
   vm_name                                = "MAZDO${upper(var.ENVIRONMENT)}${element(var.SERVERNAMES, 2)}"
@@ -113,10 +114,35 @@ module "pool_agent4-ws2019-vs2019" {
   AZURERM_VIRTUAL_NETWORK_MAIN_NAME      = "${data.azurerm_virtual_network.data.name}"
   AZURERM_SUBNET_ID                      = "${data.azurerm_subnet.data.id}"
   AZURERM_NETWORK_SECURITY_GROUP_MAIN_ID = "${data.azurerm_network_security_group.data.id}"
-  VM                                     = "${element(var.SERVERNAMES, 3)}"
+  VM                                     = "${element(var.SERVERNAMES, 3)}"  
   BRANCH                                 = "${var.BRANCH}"
   TAGS                                   = "${var.TAGS}"
   vm_name                                = "MAZDO${upper(var.ENVIRONMENT)}${element(var.SERVERNAMES, 3)}"
+  vm_size                                = "${var.VM_SIZE}"
+  run_date                               = "${var.RUN_DATE}"
+}
+
+
+
+module "pool_agent5-ws2019-vs2019" {
+  source                                 = "./modules/azdo_ws2019agent"
+  VSTS_POOL_PREFIX                       = "${var.VSTS_POOL_PREFIX}"
+  VSTS_ACCOUNT                           = "${var.VSTS_ACCOUNT}"
+  VSTS_TOKEN                             = "${var.VSTS_TOKEN}"
+  ADMIN_USERNAME                         = "${var.ADMIN_USERNAME}"
+  ADMIN_PASSWORD                         = "${var.ADMIN_PASSWORD}"
+  ADMIN_SSHKEYPATH                       = "${var.ADMIN_SSHKEYPATH}"
+  ADMIN_SSHKEYDATA                       = "${var.ADMIN_SSHKEYDATA}"
+  AZURE_REGION                           = "${var.AZURE_REGION}"
+  AZURERM_RESOURCE_GROUP_MAIN_NAME       = "${azurerm_resource_group.main.name}"
+  AZURERM_RESOURCE_GROUP_MAIN_LOCATION   = "${azurerm_resource_group.main.location}"
+  AZURERM_VIRTUAL_NETWORK_MAIN_NAME      = "${data.azurerm_virtual_network.data.name}"
+  AZURERM_SUBNET_ID                      = "${data.azurerm_subnet.data.id}"
+  AZURERM_NETWORK_SECURITY_GROUP_MAIN_ID = "${data.azurerm_network_security_group.data.id}"
+  VM                                     = "${element(var.SERVERNAMES, 4)}"
+  BRANCH                                 = "${var.BRANCH}"
+  TAGS                                   = "${var.TAGS}"
+  vm_name                                = "MAZDO${upper(var.ENVIRONMENT)}${element(var.SERVERNAMES, 4)}"
   vm_size                                = "${var.VM_SIZE}"
   run_date                               = "${var.RUN_DATE}"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -121,28 +121,3 @@ module "pool_agent4-ws2019-vs2019" {
   vm_size                                = "${var.VM_SIZE}"
   run_date                               = "${var.RUN_DATE}"
 }
-
-
-
-module "pool_agent5-ws2019-vs2019" {
-  source                                 = "./modules/azdo_ws2019agent"
-  VSTS_POOL_PREFIX                       = "${var.VSTS_POOL_PREFIX}"
-  VSTS_ACCOUNT                           = "${var.VSTS_ACCOUNT}"
-  VSTS_TOKEN                             = "${var.VSTS_TOKEN}"
-  ADMIN_USERNAME                         = "${var.ADMIN_USERNAME}"
-  ADMIN_PASSWORD                         = "${var.ADMIN_PASSWORD}"
-  ADMIN_SSHKEYPATH                       = "${var.ADMIN_SSHKEYPATH}"
-  ADMIN_SSHKEYDATA                       = "${var.ADMIN_SSHKEYDATA}"
-  AZURE_REGION                           = "${var.AZURE_REGION}"
-  AZURERM_RESOURCE_GROUP_MAIN_NAME       = "${azurerm_resource_group.main.name}"
-  AZURERM_RESOURCE_GROUP_MAIN_LOCATION   = "${azurerm_resource_group.main.location}"
-  AZURERM_VIRTUAL_NETWORK_MAIN_NAME      = "${data.azurerm_virtual_network.data.name}"
-  AZURERM_SUBNET_ID                      = "${data.azurerm_subnet.data.id}"
-  AZURERM_NETWORK_SECURITY_GROUP_MAIN_ID = "${data.azurerm_network_security_group.data.id}"
-  VM                                     = "${element(var.SERVERNAMES, 4)}"
-  BRANCH                                 = "${var.BRANCH}"
-  TAGS                                   = "${var.TAGS}"
-  vm_name                                = "MAZDO${upper(var.ENVIRONMENT)}${element(var.SERVERNAMES, 4)}"
-  vm_size                                = "${var.VM_SIZE}"
-  run_date                               = "${var.RUN_DATE}"
-}

--- a/terraform/modules/azdo_ubuntuagent/variables.tf
+++ b/terraform/modules/azdo_ubuntuagent/variables.tf
@@ -54,7 +54,7 @@ variable "BRANCH" {
 variable "VSTS_AGENT_COUNT" {
   type        = number
   description = "The number of Azure DevOps agents to install on the VM"
-  default     = 3
+  default     = 2
 }
 variable "TAGS" {
   type = "map"


### PR DESCRIPTION
Add extra ubuntu server and add reduce default ubuntu agent count down to two in line with current AzDo configuration.

- @pheonixtechnical - `Is there a way of us having some more agents in the linux pool? Even if temporarily, as we seem to be choking out a bit the last few days with both teams using them quite alot (plz)`