### PR TITLE
BLOCKED - Update Windows VM to 256GB SSD drive

### DIFF
--- a/terraform/modules/azdo_ubuntuagent/main.tf
+++ b/terraform/modules/azdo_ubuntuagent/main.tf
@@ -33,7 +33,7 @@ resource "azurerm_virtual_machine" "VM" {
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Premium_LRS"
-    disk_size_gb      = "256"
+    disk_size_gb      = "128"
   }
   os_profile {
     computer_name  = "${var.vm_name}"

--- a/terraform/modules/azdo_ubuntuagent/main.tf
+++ b/terraform/modules/azdo_ubuntuagent/main.tf
@@ -33,7 +33,7 @@ resource "azurerm_virtual_machine" "VM" {
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Premium_LRS"
-    disk_size_gb      = "128"
+    disk_size_gb      = "256"
   }
   os_profile {
     computer_name  = "${var.vm_name}"

--- a/terraform/modules/azdo_ws2019agent/main.tf
+++ b/terraform/modules/azdo_ws2019agent/main.tf
@@ -36,7 +36,7 @@ resource "azurerm_virtual_machine" "WSVM" {
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Premium_LRS"
-    disk_size_gb      = "128"
+    disk_size_gb      = "256"
   }
   os_profile {
     computer_name  = "${var.vm_name}"

--- a/terraform/modules/azdo_ws2019agent/main.tf
+++ b/terraform/modules/azdo_ws2019agent/main.tf
@@ -35,8 +35,8 @@ resource "azurerm_virtual_machine" "WSVM" {
     name              = "${var.vm_name}-osdisk"
     caching           = "ReadWrite"
     create_option     = "FromImage"
-    managed_disk_type = "Standard_LRS"
-
+    managed_disk_type = "Premium_LRS"
+    disk_size_gb      = "128"
   }
   os_profile {
     computer_name  = "${var.vm_name}"


### PR DESCRIPTION
Because the windows images have all the VS image stuff installed space gets used very quickly. This will hopefully mean they take a little longer to fill up.