### PR TITLE
Correct RG name after migration

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,7 +11,7 @@ resource "azurerm_resource_group" "main" {
 }
 
 data "azurerm_resource_group" "data" {
-  name = "AzDoLive-RG"
+  name = "m-spokeconfig-RG"
 }
 
 data "azurerm_virtual_network" "data" {


### PR DESCRIPTION
We migrated to the new style of hub, this means the VNet and NSGs are now in a different resource group.