### PR TITLE
Remove last linux agent

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -32,8 +32,8 @@ resource "azurerm_resource_group" "vm-rg" {
   tags     = merge(var.TAGS, { "ACCOUNT" = "${var.VSTS_ACCOUNT}", "RUN_DATE" = "${local.run_date}" })
 }
 
-module "pool_agent1-ubuntu" {
-  source                                 = "./modules/azdo_ubuntuagent"
+module "pool_agent1-ws2019-vs2019" {
+  source                                 = "./modules/azdo_ws2019agent"
   VSTS_POOL_PREFIX                       = var.VSTS_POOL_PREFIX
   VSTS_ACCOUNT                           = var.VSTS_ACCOUNT
   VSTS_TOKEN                             = var.VSTS_TOKEN
@@ -51,29 +51,6 @@ module "pool_agent1-ubuntu" {
   BRANCH                                 = var.BRANCH
   TAGS                                   = var.TAGS
   vm_name                                = "MAZDO${upper(var.ENVIRONMENT)}${element(var.SERVERNAMES, 0)}"
-  vm_size                                = var.VM_SIZE
-  run_date                               = local.run_date
-}
-
-module "pool_agent2-ws2019-vs2019" {
-  source                                 = "./modules/azdo_ws2019agent"
-  VSTS_POOL_PREFIX                       = var.VSTS_POOL_PREFIX
-  VSTS_ACCOUNT                           = var.VSTS_ACCOUNT
-  VSTS_TOKEN                             = var.VSTS_TOKEN
-  ADMIN_USERNAME                         = var.ADMIN_USERNAME
-  ADMIN_PASSWORD                         = var.ADMIN_PASSWORD
-  ADMIN_SSHKEYPATH                       = var.ADMIN_SSHKEYPATH
-  ADMIN_SSHKEYDATA                       = var.ADMIN_SSHKEYDATA
-  AZURE_REGION                           = var.AZURE_REGION
-  AZURERM_RESOURCE_GROUP_MAIN_NAME       = azurerm_resource_group.vm-rg.name
-  AZURERM_RESOURCE_GROUP_MAIN_LOCATION   = azurerm_resource_group.vm-rg.location
-  AZURERM_VIRTUAL_NETWORK_MAIN_NAME      = data.azurerm_virtual_network.spoke-vnet.name
-  AZURERM_SUBNET_ID                      = data.azurerm_subnet.spoke-vnet-subnet.id
-  AZURERM_NETWORK_SECURITY_GROUP_MAIN_ID = data.azurerm_network_security_group.spoke-nsg.id
-  VM                                     = element(var.SERVERNAMES, 1)
-  BRANCH                                 = var.BRANCH
-  TAGS                                   = var.TAGS
-  vm_name                                = "MAZDO${upper(var.ENVIRONMENT)}${element(var.SERVERNAMES, 1)}"
   vm_size                                = var.VM_SIZE
   run_date                               = local.run_date
 }


### PR DESCRIPTION
With the configuration of the new VMSS agents corrected for DE and DS builds, these agents should no longer be needed and all Linux agents can migrate to be created as part of the VMSS.

This PR removes the last F8 Ubuntu agent from TF but leaves the modules remaining incase we need to fall back if the VMSS does not work as expected.